### PR TITLE
⚡️ Dockerfile for tiny static image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM rust:latest
-
-WORKDIR /usr/src/helium
-
+FROM alpine:latest AS build
+WORKDIR /helium
 COPY . .
+RUN apk add --no-cache curl alpine-sdk openssl-dev
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN source $HOME/.cargo/env && cargo build --release
+RUN chmod +x target/release/helium
 
-RUN cargo build --release
-
-RUN cargo install --path .
-
-CMD ["/usr/local/cargo/bin/helium"]
+FROM scratch
+COPY --from=build /helium/target/release/helium .
+CMD ["/helium"]


### PR DESCRIPTION
The Dockerfile builds a static binary and copies it into an empty image, producing a final image which is currently ~14MB big.